### PR TITLE
Staff page modal implementation

### DIFF
--- a/assets/css/staff.css
+++ b/assets/css/staff.css
@@ -21,7 +21,6 @@ p {
     margin: 5px 15px;
     text-align: center;
     width: 200px;
-    transition: 250ms ease-in;
 }
 
 .staff-btn:hover {

--- a/assets/css/staff.css
+++ b/assets/css/staff.css
@@ -14,13 +14,18 @@ p {
     flex-wrap: wrap;
 }
 
-.staff-card {
+.staff-card{
     display: inline-block;
     border: 1px solid black;
     padding: 15px 10px;
     margin: 5px 15px;
     text-align: center;
     width: 200px;
+    transition: 250ms ease-in;
+}
+
+.staff-btn:hover {
+    cursor: pointer;
 }
 
 .profile-picture {
@@ -38,9 +43,21 @@ p {
 }
 
 .mod {
-    color: #DEC20B;
+    color: goldenrod;
 }
 
 .coco {
     color: orange;
+}
+
+.staff-btn {
+    height: 50px;
+    width: 100px;
+    font-size: 18px;
+    margin: 10px;
+}
+
+.modal-content {
+    background-color: white;
+    height: 500px;
 }

--- a/assets/css/staff.css
+++ b/assets/css/staff.css
@@ -14,7 +14,7 @@ p {
     flex-wrap: wrap;
 }
 
-.staff-card{
+.staff-card {
     display: inline-block;
     border: 1px solid black;
     padding: 15px 10px;

--- a/assets/scripts/modals.js
+++ b/assets/scripts/modals.js
@@ -1,0 +1,31 @@
+//MODAL SCRIPTS ----------------------------------------------------------------
+const modals = document.querySelectorAll('.modal');
+const modalTriggers = document.querySelectorAll('.staff-btn');
+const modalClose = document.querySelectorAll('.modal-close');
+const modalBackgrounds = document.querySelectorAll(".modal-background")
+
+for (let i = 0; i < modals.length; i++) {
+    // Give all modals, open buttons, close buttons and modal backgrounds a corresponding "target" attribute.
+    modals[i].setAttribute('target', i);
+    modalTriggers[i].setAttribute('target', i);
+    modalClose[i].setAttribute('target', i);
+    modalBackgrounds[i].setAttribute('target', i);
+
+    //Event listener to trigger the modal on click event
+    modalTriggers[i].addEventListener('click', function(){
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })    
+
+    //Event listener to close the modal on click event
+    modalClose[i].addEventListener('click', function(){
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })    
+
+    //Event listener to close the modal when background is clicked
+    modalBackgrounds[i].addEventListener('click', function() {
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })
+}

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -1,3 +1,4 @@
+//NAV SCRIPTS ----------------------------------------------------------------
 const burger = document.querySelector('.burger');
 const navElements = document.querySelector('#navbar-items');
 
@@ -5,3 +6,36 @@ burger.addEventListener('click', function(){
     burger.classList.toggle('is-active');
     navElements.classList.toggle('is-active');
 })
+
+
+//MODAL SCRIPTS ----------------------------------------------------------------
+const modals = document.querySelectorAll('.modal');
+const modalTriggers = document.querySelectorAll('.staff-btn');
+const modalClose = document.querySelectorAll('.modal-close');
+const modalBackgrounds = document.querySelectorAll(".modal-background")
+
+for (let i = 0; i < modals.length; i++) {
+    // Give all modals, open buttons, close buttons and modal backgrounds a corresponding "target" attribute.
+    modals[i].setAttribute('target', i);
+    modalTriggers[i].setAttribute('target', i);
+    modalClose[i].setAttribute('target', i);
+    modalBackgrounds[i].setAttribute('target', i);
+
+    //Event listener to trigger the modal on click event
+    modalTriggers[i].addEventListener('click', function(){
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })    
+
+    //Event listener to close the modal on click event
+    modalClose[i].addEventListener('click', function(){
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })    
+
+    //Event listener to close the modal when background is clicked
+    modalBackgrounds[i].addEventListener('click', function() {
+        const targetIndex = this.getAttribute('target')
+        modals[targetIndex].classList.toggle('is-active');
+    })
+}

--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -6,36 +6,3 @@ burger.addEventListener('click', function(){
     burger.classList.toggle('is-active');
     navElements.classList.toggle('is-active');
 })
-
-
-//MODAL SCRIPTS ----------------------------------------------------------------
-const modals = document.querySelectorAll('.modal');
-const modalTriggers = document.querySelectorAll('.staff-btn');
-const modalClose = document.querySelectorAll('.modal-close');
-const modalBackgrounds = document.querySelectorAll(".modal-background")
-
-for (let i = 0; i < modals.length; i++) {
-    // Give all modals, open buttons, close buttons and modal backgrounds a corresponding "target" attribute.
-    modals[i].setAttribute('target', i);
-    modalTriggers[i].setAttribute('target', i);
-    modalClose[i].setAttribute('target', i);
-    modalBackgrounds[i].setAttribute('target', i);
-
-    //Event listener to trigger the modal on click event
-    modalTriggers[i].addEventListener('click', function(){
-        const targetIndex = this.getAttribute('target')
-        modals[targetIndex].classList.toggle('is-active');
-    })    
-
-    //Event listener to close the modal on click event
-    modalClose[i].addEventListener('click', function(){
-        const targetIndex = this.getAttribute('target')
-        modals[targetIndex].classList.toggle('is-active');
-    })    
-
-    //Event listener to close the modal when background is clicked
-    modalBackgrounds[i].addEventListener('click', function() {
-        const targetIndex = this.getAttribute('target')
-        modals[targetIndex].classList.toggle('is-active');
-    })
-}

--- a/staff.html
+++ b/staff.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="assets/css/bulma_styles.css">
         <link rel='icon' href='favicon.ico' type='image/x-icon'>
         <script src="assets/scripts/script.js" defer></script>
+        <script src="assets/scripts/modals.js" defer></script>
         <title>Server Staff</title>
     </head>
     <body>

--- a/staff.html
+++ b/staff.html
@@ -122,12 +122,13 @@
             </section> 
 
             <!-- MODALS -->
-            <!-- NOTE: Modals *must* be in the same order as the staff cards above to ensure the right modals become linked to the right card (i.e Brussels's modal must come before Fede's) -->
+            <!-- NOTE:  Modals *must* be in the same order as the staff cards above to ensure the right modals become linked to the right card (i.e Brussels's modal must come before Fede's) 
+                        this does not include any staff cards that do not have modals. -->
             <section class="modals">
                 <div class="modal">
                     <div class="modal-background"></div>
                     <div class="modal-content">
-                        <p>Hello, Lyall</p>
+                        <p>Lyall#0001</p>
                     </div>
                     <a class="modal-close is-large" aria-label="close"></a>
                   </div>

--- a/staff.html
+++ b/staff.html
@@ -86,6 +86,7 @@
                     <div class="staff-card has-background-white">
                         <img class="profile-picture" src="https://cdn.discordapp.com/avatars/715846451334217728/cacae335b4d9aa9bf6924a8d85368812.webp?size=128">
                         <p class="name mod">Lyall (he/him)</p>
+                        <button class="staff-btn">See Bio</button>
                     </div>
                 </div>
             </section>
@@ -119,6 +120,18 @@
                     </div>
                 </div>
             </section> 
+
+            <!-- MODALS -->
+            <!-- NOTE: Modals *must* be in the same order as the staff cards above to ensure the right modals become linked to the right card (i.e Brussels's modal must come before Fede's) -->
+            <section class="modals">
+                <div class="modal">
+                    <div class="modal-background"></div>
+                    <div class="modal-content">
+                        <p>Hello, Lyall</p>
+                    </div>
+                    <a class="modal-close is-large" aria-label="close"></a>
+                  </div>
+            </section>
         </main>
         <footer class="footer has-text-centered">
             <div class="content ">


### PR DESCRIPTION
## What issue is this solving?

No individual issue but contributes to #38

### Description
Adds the scripts and an example modal on my staff card without any content (yet).

Also changes the mod name color to `goldenrod` to be more representative of the actual color which also improves contrast/readability.

Modal button:
![image](https://user-images.githubusercontent.com/78568904/146759928-1e7b00e2-3aa3-441c-9185-1ed280725860.png)

Example modal:
![image](https://user-images.githubusercontent.com/78568904/146759951-4097cced-b520-43e8-b8ba-735f2d877afa.png)


## Any helpful knowledge/context for the reviewer?

As the script *should* handle new new modals adding bios for another user can be done purely in HTML by adding the modal div itself and the trigger button. However any modals present must be in the same order as their relevant staff cards to ensure the right modals and buttons are linked.

- Any new dependencies to install? ❌ 
- Any special requirements to test? ❌ 


### Please make sure you've attempted to meet the following coding standards

- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
