### PR TITLE
Add sharing code view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Home } from './Views/Home.jsx';
 import { Contact } from './Views/Contact.jsx';
+import { SharingCode } from './Views/SharingCode.jsx';
 import { GettingHelp } from './Views/GettingHelp.jsx';
 import { FAQ } from './Views/FAQ.jsx';
 import { Header } from './Components/Header.jsx';
@@ -16,6 +17,7 @@ function App() {
       <Routes>
         <Route path='/' element={<Home />} />
         <Route path='/contact' element={<Contact />} />
+        <Route path='/sharing-code' element={<SharingCode />} />
         <Route path='/getting-help' element={<GettingHelp />} />
         <Route path='/faq' element={<FAQ />} />
       </Routes>

--- a/src/Views/SharingCode.jsx
+++ b/src/Views/SharingCode.jsx
@@ -1,0 +1,49 @@
+import SingleLine from '../assets/img/singleline.png';
+import Snippet from '../assets/img/snippet.png';
+import CCSharing from '../assets/img/cc_sharing.png';
+
+export const SharingCode = () => {
+  return(
+    <main class="has-text-centered">
+      <div class="container p-2">
+        <h1 class="is-size-1 mt-6">How to share code effectively:</h1>
+        <p class="mb-6">A (non-exhaustive) list of some of the preferred ways to share code.</p>
+      </div> 
+      <section class="container has-background-white mb-6 p-6">
+        <div>
+          <h2 class="is-size-2 p-0">Small Snippets</h2>
+
+          <p>If sharing a single line of code, wrap it in a pair of backticks ( ` ):</p>
+          <img src={SingleLine} alt="single line code" />
+
+          <p>For a larger chunk of code, wrap it in three backticks ( ` ) with the name of the language:</p>
+          <img src={Snippet} alt="multi line code" />
+          <p>This has a number of benefits such as improved readability and syntax highlighting.</p>
+        </div>
+      </section>
+      <section class="container has-background-white mb-6 p-6">
+        <div>
+          <h2 class="is-size-2 p-0">Larger Code Files</h2>
+          <p>If you need to send a larger code snippet or a whole file, please avoid uploading it directly as a file (as file uploads are not permitted for security reasons) and instead use one of the options listed below:</p>
+          <hr />
+          <section class="container">
+            <h3 class="is-size-3">1. Exporting Code from Codecademy</h3>
+            <p>If you need to export code directly from the Codecademy workspace, you can click on the Tools header on the navbar and export your code to a gist, which you can then share a link to:</p>
+            <img src={CCSharing} alt="Codecademy Gist" />
+          </section>
+          <hr />
+          <section class="container">
+            <h3 class="is-size-3">2. Sharing off-platform code</h3>
+            <p>To share off platform code you can use a code-sharing site. Some of these are:</p>
+            <a class="site-link" href="https://gist.github.com/">GitHub Gist</a>
+            <br />
+            <a class="site-link" href="https://codepen.io/">Codepen</a>
+            <br />
+            <a class="site-link" href="https://jsfiddle.net/">JSFiddle</a>
+            <p>Or you could share a link to a GitHub repository with your code.</p>
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+};


### PR DESCRIPTION
## What issue is this solving?

<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #47 

### Description
<!-- Brief description of change -->
Added Sharing Code page view and routing for it. To see the page, head to the URL address of the web app followed by `/sharing-code`. Using the navbar or button cards on the homepage will not work as changes to the anchor tag references were made in #58. Once #58 and this PR are both merged, the navbar and button cards will lead to the correct page.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Any new dependencies to install? No
- Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards

- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
