### PR TITLE
style server staff modal, make separate component

### DIFF
--- a/src/Components/StaffCard.jsx
+++ b/src/Components/StaffCard.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
+import { StaffCardModal } from './StaffCardModal';
 
 export const StaffCard = (props) => {
-  const { name, pfp, role, bio } = props;
   const [isActive, setIsActive] = useState(false);
+  const { name, pfp, role } = props;
 
   return (
     <>
@@ -14,20 +15,11 @@ export const StaffCard = (props) => {
         </button>
       </div>
 
-      <div className={`${isActive ? 'is-active' : ''} modal`}>
-        <div
-          onClick={() => setIsActive(false)}
-          className="modal-background"
-        ></div>
-        <div className="modal-content">
-          <p>{bio}</p>
-        </div>
-        <button
-          onClick={() => setIsActive(false)}
-          className="modal-close is-large"
-          aria-label="close"
-        ></button>
-      </div>
+      <StaffCardModal
+        {...props}
+        isActive={isActive}
+        setIsActive={setIsActive}
+      />
     </>
   );
 };

--- a/src/Components/StaffCardModal.jsx
+++ b/src/Components/StaffCardModal.jsx
@@ -1,0 +1,30 @@
+export const StaffCardModal = ({ name, pfp, bio, isActive, setIsActive }) => {
+  return (
+    <>
+      <div className={`${isActive ? 'is-active' : ''} modal`}>
+        <div
+          onClick={() => setIsActive(false)}
+          className="modal-background"
+        ></div>
+
+        <div className="modal-content columns is-vcentered p-4">
+          <div className="column">
+            <img
+              alt={`${name}'s profile`}
+              className="profile-picture"
+              src={pfp}
+            />
+            <p className="title is-4 mt-2">{name}</p>
+            <div className="content">{bio}</div>
+          </div>
+        </div>
+
+        <button
+          onClick={() => setIsActive(false)}
+          className="modal-close is-large"
+          aria-label="close"
+        ></button>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## What issue is this solving?

<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #79

### Description
Styles the server staff modal. Moves out the modal content to a separate component from the card.

## Any helpful knowledge/context for the reviewer?
Desktop/mobile screenshots:
<img width="1004" alt="cc_modal" src="https://user-images.githubusercontent.com/68908416/156209359-81359883-d4fc-433f-ab50-64c2e12a456a.PNG">

<img width="366" alt="cc_modal_mobile" src="https://user-images.githubusercontent.com/68908416/156209436-c199a768-896e-4579-b85f-211bd9fcee90.PNG">

- Any new dependencies to install? No
- Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards

- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
