### PR TITLE
updates to open resource links in new tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 
 .eslintcache
 .vscode
+.idea

--- a/src/Components/ResourceLink.jsx
+++ b/src/Components/ResourceLink.jsx
@@ -4,7 +4,9 @@ export const ResourceLink = (props) => {
   return (
     <div className="resource-link">
       <h3>
-        <a href={url}>{title}</a>
+        <a target="_blank" rel="noopener noreferrer" href={url}>
+          {title}
+        </a>
       </h3>
       {author && (
         <p className="resource-author">


### PR DESCRIPTION
## What issue is this solving?

Closes #116 

### Description
Added changes to open the resource links in a new tab.
Original issue describes error alert when using `target = '_blank'`.

It is due to security issue mentioned [here](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/). 

Added `rel="noopener noreferrer"` to address the security alert. 

As an aside, added `.idea` to `.gitignore` to support users that uses Jetbrains IDE. Hope that's ok. :) 

- Any new dependencies to install?
No

- Any special requirements to test?
No

### Please make sure you've attempted to meet the following coding standards

- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
