### PR TITLE
add integration tests for nav bar links

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,54 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import userEvent from '@testing-library/user-event';
+import App from './app';
 
-test('renders learn react link', () => {
+window.scroll = jest.fn();
+
+test('renders the Home page', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(
+    screen.getAllByText(/Welcome to the Codecademy Discord Community/i)[0]
+  ).toBeInTheDocument();
+});
+
+test('navigates to and renders the Server Staff page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('server-staff-link'));
+  expect(screen.getAllByText(/Admins/i)[0]).toBeInTheDocument();
+});
+
+test('navigates to and renders the Contact Us page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('contact-us-link'));
+  expect(screen.getAllByText(/The ModMail Bot/i)[0]).toBeInTheDocument();
+});
+
+test('navigates to and renders the Sharing Code page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('sharing-code-link'));
+  expect(screen.getByText(/small snippets/i)).toBeInTheDocument();
+});
+
+test('navigates to and renders the Getting Help page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('getting-help-link'));
+  expect(screen.getByText(/Let us see your code/i)).toBeInTheDocument();
+});
+
+test('navigates to and renders the Resources page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('resources-link'));
+  expect(screen.getByText(/Frontend Mentor/i)).toBeInTheDocument();
+});
+
+test('navigates to and renders the FAQ page', async () => {
+  render(<App />);
+  const user = userEvent.setup();
+  await user.click(screen.getByTestId('faq-link'));
+  expect(screen.getByText(/Is Codecademy Down/i)).toBeInTheDocument();
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,54 +1,58 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from './app';
+import App from './App';
 
 window.scroll = jest.fn();
 
-test('renders the Home page', () => {
-  render(<App />);
-  expect(
-    screen.getAllByText(/Welcome to the Codecademy Discord Community/i)[0]
-  ).toBeInTheDocument();
+describe('home page', () => {
+  it('renders the Home page', () => {
+    render(<App />);
+    expect(
+      screen.getByText(/Welcome to the Codecademy Discord Community/)
+    ).toBeInTheDocument();
+  });
 });
 
-test('navigates to and renders the Server Staff page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('server-staff-link'));
-  expect(screen.getAllByText(/Admins/i)[0]).toBeInTheDocument();
-});
+describe('navigation of navbar links', () => {
+  it('navigates to and renders the Server Staff page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('server-staff-link'));
+    expect(screen.getAllByText(/Admins/)[0]).toBeInTheDocument();
+  });
 
-test('navigates to and renders the Contact Us page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('contact-us-link'));
-  expect(screen.getAllByText(/The ModMail Bot/i)[0]).toBeInTheDocument();
-});
+  it('navigates to and renders the Contact Us page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('contact-us-link'));
+    expect(screen.getAllByText(/The ModMail Bot/)[0]).toBeInTheDocument();
+  });
 
-test('navigates to and renders the Sharing Code page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('sharing-code-link'));
-  expect(screen.getByText(/small snippets/i)).toBeInTheDocument();
-});
+  it('navigates to and renders the Sharing Code page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('sharing-code-link'));
+    expect(screen.getByText(/Small Snippets/)).toBeInTheDocument();
+  });
 
-test('navigates to and renders the Getting Help page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('getting-help-link'));
-  expect(screen.getByText(/Let us see your code/i)).toBeInTheDocument();
-});
+  it('navigates to and renders the Getting Help page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('getting-help-link'));
+    expect(screen.getByText(/Let us see your code/)).toBeInTheDocument();
+  });
 
-test('navigates to and renders the Resources page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('resources-link'));
-  expect(screen.getByText(/Frontend Mentor/i)).toBeInTheDocument();
-});
+  it('navigates to and renders the Resources page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('resources-link'));
+    expect(screen.getByText(/Frontend Mentor/)).toBeInTheDocument();
+  });
 
-test('navigates to and renders the FAQ page', async () => {
-  render(<App />);
-  const user = userEvent.setup();
-  await user.click(screen.getByTestId('faq-link'));
-  expect(screen.getByText(/Is Codecademy Down/i)).toBeInTheDocument();
+  it('navigates to and renders the FAQ page', async () => {
+    render(<App />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('faq-link'));
+    expect(screen.getByText(/Is Codecademy Down/)).toBeInTheDocument();
+  });
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -17,42 +17,48 @@ describe('navigation of navbar links', () => {
   it('navigates to and renders the Server Staff page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('server-staff-link'));
+    const serverStaffLink = screen.getAllByText('Server Staff')[0];
+    await user.click(serverStaffLink);
     expect(screen.getAllByText(/Admins/)[0]).toBeInTheDocument();
   });
 
   it('navigates to and renders the Contact Us page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('contact-us-link'));
+    const contactUsLink = screen.getAllByText('Contact Us')[0];
+    await user.click(contactUsLink);
     expect(screen.getAllByText(/The ModMail Bot/)[0]).toBeInTheDocument();
   });
 
   it('navigates to and renders the Sharing Code page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('sharing-code-link'));
+    const sharingCodeLink = screen.getAllByText('Sharing Code')[0];
+    await user.click(sharingCodeLink);
     expect(screen.getByText(/Small Snippets/)).toBeInTheDocument();
   });
 
   it('navigates to and renders the Getting Help page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('getting-help-link'));
+    const gettingHelpLink = screen.getAllByText('Getting Help')[0];
+    await user.click(gettingHelpLink);
     expect(screen.getByText(/Let us see your code/)).toBeInTheDocument();
   });
 
   it('navigates to and renders the Resources page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('resources-link'));
+    const resourcesLink = screen.getAllByText('Resources')[0];
+    await user.click(resourcesLink);
     expect(screen.getByText(/Frontend Mentor/)).toBeInTheDocument();
   });
 
   it('navigates to and renders the FAQ page', async () => {
     render(<App />);
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('faq-link'));
+    const faqLink = screen.getAllByText('FAQ')[0];
+    await user.click(faqLink);
     expect(screen.getByText(/Is Codecademy Down/)).toBeInTheDocument();
   });
 });

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -42,18 +42,12 @@ export const Header = () => {
             <Link className="navbar-item" to="/" onClick={handleNavigate}>
               Home
             </Link>
-            <Link
-              className="navbar-item"
-              to="/staff"
-              data-testid="server-staff-link"
-              onClick={handleNavigate}
-            >
+            <Link className="navbar-item" to="/staff" onClick={handleNavigate}>
               Server Staff
             </Link>
             <Link
               className="navbar-item"
               to="/contact"
-              data-testid="contact-us-link"
               onClick={handleNavigate}
             >
               Contact Us
@@ -61,7 +55,6 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/sharing-code"
-              data-testid="sharing-code-link"
               onClick={handleNavigate}
             >
               Sharing Code
@@ -69,7 +62,6 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/getting-help"
-              data-testid="getting-help-link"
               onClick={handleNavigate}
             >
               Getting Help
@@ -77,17 +69,11 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/resources"
-              data-testid="resources-link"
               onClick={handleNavigate}
             >
               Resources
             </Link>
-            <Link
-              className="navbar-item"
-              to="/faq"
-              data-testid="faq-link"
-              onClick={handleNavigate}
-            >
+            <Link className="navbar-item" to="/faq" onClick={handleNavigate}>
               FAQ
             </Link>
           </div>

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -42,12 +42,18 @@ export const Header = () => {
             <Link className="navbar-item" to="/" onClick={handleNavigate}>
               Home
             </Link>
-            <Link className="navbar-item" to="/staff" onClick={handleNavigate}>
+            <Link
+              className="navbar-item"
+              to="/staff"
+              data-testid="server-staff-link"
+              onClick={handleNavigate}
+            >
               Server Staff
             </Link>
             <Link
               className="navbar-item"
               to="/contact"
+              data-testid="contact-us-link"
               onClick={handleNavigate}
             >
               Contact Us
@@ -55,6 +61,7 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/sharing-code"
+              data-testid="sharing-code-link"
               onClick={handleNavigate}
             >
               Sharing Code
@@ -62,6 +69,7 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/getting-help"
+              data-testid="getting-help-link"
               onClick={handleNavigate}
             >
               Getting Help
@@ -69,11 +77,17 @@ export const Header = () => {
             <Link
               className="navbar-item"
               to="/resources"
+              data-testid="resources-link"
               onClick={handleNavigate}
             >
               Resources
             </Link>
-            <Link className="navbar-item" to="/faq" onClick={handleNavigate}>
+            <Link
+              className="navbar-item"
+              to="/faq"
+              data-testid="faq-link"
+              onClick={handleNavigate}
+            >
               FAQ
             </Link>
           </div>


### PR DESCRIPTION
## What issue is this solving?

<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #111

### Description
Adds basic integration tests that checks rendering and navigation to all the pages linked from the nav-bar. This will make it more clear and simple to add more tests as additional features are added to the site. Also adds some data-testid props to the Links in order to make navigation easier to perform during the tests. Mocks window.scroll with jest in order to avoid error during testing since window object is only available in the browser.

Run the tests with 
`
npm run test
`

## Any helpful knowledge/context for the reviewer?

- Any new dependencies to install? No
- Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards

- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
